### PR TITLE
Tried to comply to the XDG specifications.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,7 @@ builds:
       - amd64
       - arm
       - arm64
-      - 386
+      - '386'
     ldflags:
       - -s -w -X main.version=v{{.Version}}
     ignore: # problems with build

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Simply remove the executable or use:
 brew uninstall rem
 ```
 
-Rem stores its trash by default at `~/.remTrash`.
+Rem stores its trash by default at `$XDG_DATA_HOME/remTrash`. Alternatively, you can supply the path to the trash in the environment variable `REM_TRASH`, or supplying it with the `-d` command line argument.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -58,24 +58,24 @@ Simply remove the executable or use:
 brew uninstall rem
 ```
 
-Rem stores its trash by default at `$XDG_DATA_HOME/remTrash`. Alternatively, you can supply the path to the trash in the environment variable `REM_TRASH`, or supplying it with the `-d` command line argument.
-
 ## Usage
 
 ```text
-Usage: rem [-t/--set-trash <dir>] [--disable-copy] [--permanent | -u/--undo] <file> ...
+Usage: rem [-t/--set-dir <dir>] [--disable-copy] [--permanent | -u/--undo] <file> ...
        rem [-d/--directory | --empty | -h/--help | -v/--version | -l/--list]
 Options:
    -u/--undo              restore a file
    -l/--list              list files in trash
    --empty                empty the trash permanently
    --permanent            delete a file permanently
-   -d/--directory         show path to trash
-   -t/--set-trash <dir>   set trash to dir and continue
+   -d/--directory         show path to the data dir
+   -t/--set-dir <dir>     set the data dir and continue
    --disable-copy         if files are on a different fs, don't rename by copy
    -h/--help              print this help message
    -v/--version           print Rem version
 ```
+
+Rem stores its data at `$XDG_DATA_HOME/rem` or `.local/share/rem` by default. Alternatively, set the data directory using `$REM_TRASH` or with the `-d` option.
 
 ## Thanks
 

--- a/rem.go
+++ b/rem.go
@@ -315,14 +315,6 @@ func chooseDataDir() string {
 		return dataHome + "/rem/trash"
 	}
 	return home + "/.local/share/rem"
-	// dirtyDataHome := home + "/.local/share"
-	// stats, err := os.Stat(dirtyDataHome)
-	// if !(os.IsNotExist(err)) {
-	// 	if stats.IsDir() {
-	// 		return dirtyDataHome + "/rem/trash"
-	// 	}
-	// }
-	// return home + "/.remTrash"
 }
 
 func permanentlyDeleteFile(fileName string) {


### PR DESCRIPTION
The trash directory by default is
$XDG_DATA_HOME/remTrash. If XDG_DATA_HOME is not
set, the choice of the trash directory is made in
a smart-ish way.
I know that I will definitively not use this
software if it is going to add clutter to my home
directory and I might not be the only one in that
case. Following the XDG specification could let
REM be used by more people.