### PR TITLE
Fixed check of argument usability.

### DIFF
--- a/rem.go
+++ b/rem.go
@@ -124,7 +124,7 @@ func main() {
 	// normal case
 	ensureTrashDir()
 	for i, filePath := range os.Args[1:] {
-		if !ignoreArgs[i] {
+		if !ignoreArgs[i+1] {
 			trashFile(filePath)
 		}
 	}

--- a/rem.go
+++ b/rem.go
@@ -123,8 +123,9 @@ func main() {
 	}
 	// normal case
 	ensureTrashDir()
-	for i, filePath := range os.Args[1:] {
-		if !ignoreArgs[i+1] {
+	for i, filePath := range os.Args {
+		if i == 0 { continue }
+		if !ignoreArgs[i] {
 			trashFile(filePath)
 		}
 	}


### PR DESCRIPTION
The ignoreArgs map counts arguments indexed as
they are given by the OS but the normal case loop
starts to count as the index 1 which caused an
offset of the ignored arguments.