### PR TITLE
Improved `permanentlyDeleteFile`.

### DIFF
--- a/rem.go
+++ b/rem.go
@@ -63,8 +63,13 @@ func main() {
 		color.Red("Warning, permanently deleting: ")
 		printFormattedList(os.Args[i+1:])
 		if promptBool("Confirm delete?") {
+			var err error
 			for _, filePath := range os.Args[i+1:] {
-				permanentlyDeleteFile(filePath)
+				err = permanentlyDeleteFile(filePath)
+				if err != nil {
+					fmt.Println("Could not delete " + filePath)
+					handleErr(err)
+				}
 			}
 		}
 		return
@@ -197,7 +202,10 @@ func renameByCopyAllowed(src, dst string) error {
 	err := os.Rename(src, dst)
 	if err != nil {
 		err = copy.Copy(src, dst)
-		permanentlyDeleteFile(src)
+		if err != nil {
+			return err
+		}
+		err = permanentlyDeleteFile(src)
 	}
 	return err
 }
@@ -247,8 +255,14 @@ func listFilesInTrash() []string {
 }
 
 func emptyTrash() {
-	permanentlyDeleteFile(dataDir + "/trash")
-	permanentlyDeleteFile(dataDir + "/" + logFileName)
+	err := permanentlyDeleteFile(dataDir + "/trash")
+	if err != nil {
+		handleErrStr("Couldn't delete " + dataDir + "/trash " + err.Error())
+	}
+	err = permanentlyDeleteFile(dataDir + "/" + logFileName)
+	if err != nil {
+		handleErrStr("Couldn't delete " + dataDir + "/" + logFileName + " " + err.Error())
+	}
 }
 
 func getLogFile() map[string]string {
@@ -306,8 +320,12 @@ func ensureTrashDir() {
 		return
 	}
 	if !i.IsDir() {
-		permanentlyDeleteFile(dataDir + "/trash") // not a dir so delete
-		ensureTrashDir()                          // then make it
+		err := permanentlyDeleteFile(dataDir + "/trash") // not a dir so delete
+		if err != nil {
+			handleErr(err)
+			return
+		}
+		ensureTrashDir() // then make it
 	}
 }
 
@@ -326,23 +344,37 @@ func chooseDataDir() string {
 	return home + "/.local/share/rem"
 }
 
-func permanentlyDeleteFile(fileName string) {
-	err := os.Chmod(fileName, 0700) // If some files don't have the write permission, it is impossible to delete them
-	if os.IsNotExist(err) {         // If we try to empty an already emptied trash, we will try to remove a non-existent log file. As the chmod is not critical, no error needs to be raised
-		return
+func permanentlyDeleteFile(fileName string) error {
+	err := os.RemoveAll(fileName)
+	if err == nil {
+		return nil
 	}
-	i, _ := os.Stat(fileName)
-	if i.IsDir() { // As the chmod is not recursive, we must manually crawl through the trash to chmod and remove all files by hand
-		f, _ := os.Open(fileName)
-		files, _ := f.Readdir(0)
+	err = os.Chmod(fileName, 0700) // make sure we have write permission
+	if err != nil {
+		return err
+	}
+	i, err := os.Stat(fileName)
+	if err != nil {
+		return err
+	}
+	if i.IsDir() { // recursively chmod
+		f, err := os.Open(fileName)
+		if err != nil {
+			return err
+		}
+		files, err := f.Readdir(0)
+		if err != nil {
+			return err
+		}
 		for _, subFile := range files {
-			permanentlyDeleteFile(fileName + "/" + subFile.Name())
+			err = permanentlyDeleteFile(fileName + "/" + subFile.Name())
+			if err != nil {
+				return err
+			}
 		}
 	}
-	err = os.Remove(fileName)
-	if err != nil {
-		handleErr(err)
-	}
+	err = os.RemoveAll(fileName)
+	return err
 }
 
 // Utilities:

--- a/rem.go
+++ b/rem.go
@@ -328,11 +328,8 @@ func chooseDataDir() string {
 
 func permanentlyDeleteFile(fileName string) {
 	err := os.Chmod(fileName, 0700) // If some files don't have the write permission, it is impossible to delete them
-	if err != nil {
-		if os.IsNotExist(err) { // If we try to empty an already emptied trash, we will try to remove a non-existent log file. This check ensure that no error are raised in this case
-			return
-		}
-		handleErr(err)
+	if os.IsNotExist(err) {         // If we try to empty an already emptied trash, we will try to remove a non-existent log file. As the chmod is not critical, no error needs to be raised
+		return
 	}
 	i, _ := os.Stat(fileName)
 	if i.IsDir() { // As the chmod is not recursive, we must manually crawl through the trash to chmod and remove all files by hand

--- a/rem.go
+++ b/rem.go
@@ -327,7 +327,22 @@ func chooseDataDir() string {
 }
 
 func permanentlyDeleteFile(fileName string) {
-	err := os.RemoveAll(fileName)
+	err := os.Chmod(fileName, 0700) // If some files don't have the write permission, it is impossible to delete them
+	if err != nil {
+		if os.IsNotExist(err) { // If we try to empty an already emptied trash, we will try to remove a non-existent log file. This check ensure that no error are raised in this case
+			return
+		}
+		handleErr(err)
+	}
+	i, _ := os.Stat(fileName)
+	if i.IsDir() { // As the chmod is not recursive, we must manually crawl through the trash to chmod and remove all files by hand
+		f, _ := os.Open(fileName)
+		files, _ := f.Readdir(0)
+		for _, subFile := range files {
+			permanentlyDeleteFile(fileName + "/" + subFile.Name())
+		}
+	}
+	err = os.Remove(fileName)
 	if err != nil {
 		handleErr(err)
 	}


### PR DESCRIPTION
When some file in the trash did not have the
write permission, they could not be removed and
an error was raised.
Performing a chmod 700 on files about to be
removed fixes that issue.