### PR TITLE
No prompt on empty in quiet mode.

### DIFF
--- a/rem.go
+++ b/rem.go
@@ -19,18 +19,18 @@ var (
 	helpMsg = `Rem - Get some rem sleep knowing your files are safe
 Rem is a CLI Trash
 Usage: rem [-t/--set-dir <dir>] [--disable-copy] [--permanent | -u/--undo] <file> ...
-       rem [-d/--directory | --empty | -h/--help | -v/--version | -l/--list]
+	   rem [-d/--directory | --empty | -h/--help | -v/--version | -l/--list]
 Options:
-   -u/--undo              restore a file
-   -l/--list              list files in trash
-   --empty                empty the trash permanently
-   --permanent            delete a file permanently
-   -d/--directory         show path to the data dir
-   -t/--set-dir <dir>     set the data dir and continue
-   -q/--quiet             enable quiet mode
-   --disable-copy         if files are on a different fs, don't rename by copy
-   -h/--help              print this help message
-   -v/--version           print Rem version`
+   -u/--undo			  restore a file
+   -l/--list			  list files in trash
+   --empty				empty the trash permanently
+   --permanent			delete a file permanently
+   -d/--directory		 show path to the data dir
+   -t/--set-dir <dir>	 set the data dir and continue
+   -q/--quiet			 enable quiet mode
+   --disable-copy		 if files are on a different fs, don't rename by copy
+   -h/--help			  print this help message
+   -v/--version		   print Rem version`
 	dataDir               string
 	logFileName           = ".trash.log"
 	logFile               map[string]string
@@ -100,9 +100,13 @@ func main() {
 		return
 	}
 	if hasOption, _ := argsHaveOptionLong("empty"); hasOption {
-		color.Red("Warning, permanently deleting all files in " + dataDir + "/trash")
-		if promptBool("Confirm delete?") {
+		if quietMode {
 			emptyTrash()
+		} else {
+			color.Red("Warning, permanently deleting all files in " + dataDir + "/trash")
+			if promptBool("Confirm delete?") {
+				emptyTrash()
+			}
 		}
 		return
 	}


### PR DESCRIPTION
As one might use rem in a script, it is needed to
give a way to empty the trash with no prompt. I
reused the quiet flag for that purpose.