### PR TITLE
Added -f flag.

### DIFF
--- a/rem.go
+++ b/rem.go
@@ -29,6 +29,8 @@ Options:
    -t/--set-dir <dir>     set the data dir and continue
    -q/--quiet             enable quiet mode
    --disable-copy         if files are on a different fs, don't rename by copy
+   -f/--force             Do not print error message on inexistant file,
+                          used for compatibility with rm
    -h/--help              print this help message
    -v/--version           print Rem version`
 	dataDir               string
@@ -37,6 +39,7 @@ Options:
 	renameByCopyIsAllowed = true
 
 	quietMode = false
+	forceMode = false
 )
 
 // TODO: Multiple Rem instances could clobber log file. Fix using either file locks or tcp port locks.
@@ -96,6 +99,11 @@ func main() {
 	if hasOption, _ := argsHaveOption("directory", "d"); hasOption {
 		fmt.Println(dataDir)
 		return
+	}
+
+	if hasOption, i := argsHaveOption("force", "f"); hasOption {
+		ignoreArgs[i] = true
+		forceMode = true
 	}
 
 	logFile = getLogFile()
@@ -179,7 +187,9 @@ func trashFile(path string) {
 		return
 	}
 	if !exists(path) {
-		handleErrStr(color.YellowString(path) + " does not exist")
+		if !forceMode {
+			handleErrStr(color.YellowString(path) + " does not exist")
+		}
 		return
 	}
 	toMoveTo = getTimestampedPath(toMoveTo, exists)


### PR DESCRIPTION
This flag prevents error message to be printed if
non existing files try to be deleted. This is
meant for compatibility with GNU rm if rem is
used as a drop-in replacement for rm.