### PR TITLE
Fix bug when deleting file with absolute path

### DIFF
--- a/rem.go
+++ b/rem.go
@@ -392,11 +392,6 @@ func exists(path string) bool {
 	return !(os.IsNotExist(err))
 }
 
-func existsInLog(elem string) bool {
-	_, alreadyExists := logFile[elem]
-	return alreadyExists
-}
-
 func ensureTrashDir() {
 	i, _ := os.Stat(dataDir + "/trash")
 	if !exists(dataDir + "/trash") {

--- a/rem.go
+++ b/rem.go
@@ -260,7 +260,6 @@ func trashFile(path string) {
 		return
 	}
 	toMoveTo = getTimestampedPath(toMoveTo, exists)
-	path = getTimestampedPath(path, existsInLog)
 	if flags.moveByCopyOk {
 		err = renameByCopyAllowed(path, toMoveTo)
 	} else {


### PR DESCRIPTION
When trying to delete more than once a file with
an absolute path, the following error was raised:

```
o[^.^]o ~/dev/perso/rem >touch /home/mbouillot/test
o[^.^]o ~/dev/perso/rem >./rem /home/mbouillot/test
Trashed /home/mbouillot/test
Undo using rem --undo /home/mbouillot/test
o[^.^]o ~/dev/perso/rem >touch /home/mbouillot/test
o[^.^]o ~/dev/perso/rem >./rem /home/mbouillot/test
To avoid conflicts, /home/mbouillot/.local/share/rem/trash/trash/test will now be called /home/mbouillot/.local/share/rem/trash/trash/test Dec 21 11:51:58
To avoid conflicts, /home/mbouillot/test will now be called /home/mbouillot/test Dec 21 11:51:58
error: lstat /home/mbouillot/test Dec 21 11:51:58: no such file or directory
o[^.^]o ~/dev/perso/rem >
```

This was caused by the line
`path = getTimestampedPath(path, existsInLog)`
from the function `trashFile` which changed the
name of the source file in the function when it
had the same format as in the log (absolute
path).

Removing that line fixes that issue and keeps the
current behavior.